### PR TITLE
Use yajl json parser

### DIFF
--- a/lib/pacto.rb
+++ b/lib/pacto.rb
@@ -2,7 +2,7 @@ require "pacto/version"
 
 require "httparty"
 require "hash_deep_merge"
-require "json"
+require "yajl/json_gem"
 require "json-schema"
 require "json-generator"
 require "webmock"

--- a/pacto.gemspec
+++ b/pacto.gemspec
@@ -13,14 +13,13 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/thoughtworks/pacto'
   gem.license       = 'MIT'
 
-
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
   gem.add_dependency "webmock"
-  gem.add_dependency "json"
+  gem.add_dependency "yajl-ruby"
   gem.add_dependency "json-schema", "1.0.4"
   gem.add_dependency "json-generator"
   gem.add_dependency "hash-deep-merge"


### PR DESCRIPTION
Use yajl json parser instead of the stdlib JSON parser.
The reason is because yajl shows nicer messages when deals with invalid
JSON inputs.

As Linus would say: “Talk is cheap. Show me the code.” here is an
example:

```
$ irb
irb(main):001:0> require 'json'
=> true
irb(main):002:0> JSON.parse('{"name": "contracts" "license": "MIT"}')
JSON::ParserError: 743: unexpected token at '{"name": "contracts"
"license": "MIT"}'
.
.
.

irb(main):003:0> require 'yajl/json_gem'
=> true
irb(main):004:0> JSON.parse('{"name": "contracts" "license": "MIT"}')
JSON::ParserError: parse error: after key and value, inside map, I
expect ',' or '}'
                 {"name": "contracts" "license": "MIT"}
                     (right here) ------^
.
.
.
```

As you can see yajl shows parsing errors in a nicer way.
