### PR TITLE
Move build_from_file to a factory class

### DIFF
--- a/lib/pacto.rb
+++ b/lib/pacto.rb
@@ -15,15 +15,12 @@ require "pacto/response_adapter"
 require "pacto/response"
 require "pacto/instantiated_contract"
 require "pacto/contract"
+require "pacto/contract_factory"
 require "pacto/file_pre_processor"
 
 module Pacto
   def self.build_from_file(contract_path, host, file_pre_processor=FilePreProcessor.new)
-    contract_definition_expanded = file_pre_processor.process(File.read(contract_path))
-    definition = JSON.parse(contract_definition_expanded)
-    request = Request.new(host, definition["request"])
-    response = Response.new(definition["response"])
-    Contract.new(request, response)
+    ContractFactory.build_from_file(contract_path, host, file_pre_processor)
   end
 
   def self.register(name, contract)

--- a/lib/pacto/contract_factory.rb
+++ b/lib/pacto/contract_factory.rb
@@ -1,0 +1,11 @@
+module Pacto
+  class ContractFactory
+    def self.build_from_file(contract_path, host, file_pre_processor)
+      contract_definition_expanded = file_pre_processor.process(File.read(contract_path))
+      definition = JSON.parse(contract_definition_expanded)
+      request = Request.new(host, definition["request"])
+      response = Response.new(definition["response"])
+      Contract.new(request, response)
+    end
+  end
+end

--- a/spec/pacto/contract_factory_spec.rb
+++ b/spec/pacto/contract_factory_spec.rb
@@ -1,0 +1,22 @@
+module Pacto
+  describe ContractFactory do
+    let(:host)               { 'http://localhost' }
+    let(:contract_name)      { 'contract' }
+    let(:contract_path)      { File.join('spec', 'data', "#{contract_name}.json") }
+    let(:file_pre_processor) { double('file_pre_processor') }
+    let(:file_content)       { File.read(contract_path)}
+
+    describe '.build_from_file' do
+      it 'should build a contract given a JSON file path and a host' do
+        file_pre_processor.stub(:process).and_return(file_content)
+        described_class.build_from_file(contract_path, host, file_pre_processor).
+          should be_a_kind_of(Pacto::Contract)
+      end
+
+      it 'should process files using File Pre Processor module' do
+        file_pre_processor.should_receive(:process).with(file_content).and_return(file_content)
+        described_class.build_from_file(contract_path, host, file_pre_processor)
+      end
+    end
+  end
+end

--- a/spec/pacto/pacto_spec.rb
+++ b/spec/pacto/pacto_spec.rb
@@ -1,5 +1,4 @@
 describe Pacto do
-  let(:host) { 'http://localhost' }
   let(:contract_name) { 'contract' }
   let(:contract) { double('contract') }
 
@@ -24,19 +23,19 @@ describe Pacto do
   end
 
   describe '.build_from_file' do
-    let(:contract_path) { File.join('spec', 'data', "#{contract_name}.json") }
-    let(:file_pre_processor) { double('file_pre_processor') }
-    let(:file_content) {File.read(contract_path)}
-    
-    it 'should build a contract given a JSON file path and a host' do
-      file_pre_processor.stub(:process).and_return(file_content)
-      described_class.build_from_file(contract_path, host, file_pre_processor).
-        should be_a_kind_of(Pacto::Contract)
+    let(:path)                  { 'contract/path' }
+    let(:host)                  { 'http://localhost' }
+    let(:file_pre_processor)    { double('file_pre_processor') }
+    let(:instantiated_contract) { double(:instantiated_contract) }
+
+    it 'delegates to ContractFactory' do
+      Pacto::ContractFactory.should_receive(:build_from_file).with(path, host, file_pre_processor)
+      described_class.build_from_file(path, host, file_pre_processor)
     end
-    
-    it 'should process files using File Pre Processor module' do
-      file_pre_processor.should_receive(:process).with(file_content).and_return(file_content)
-      described_class.build_from_file(contract_path, host, file_pre_processor)
+
+    it 'returns whatever the factory returns' do
+      Pacto::ContractFactory.stub(:build_from_file => instantiated_contract)
+      described_class.build_from_file(path, host, file_pre_processor).should == instantiated_contract
     end
   end
 


### PR DESCRIPTION
This `build_from_file` method is constructing a new `Contract` and is not
related with the other methods in the module `Contracts`.
The idea is to separate what is construction of a `Contract` from what is
using the contract.
The way the gem will be used has to be changed from: `Contracts.build_from_file(path, host)` to: `Contracts::ContractFactory.build_from_file(path, host)`
