### PR TITLE
Move contract validation to it's own class

### DIFF
--- a/lib/pacto.rb
+++ b/lib/pacto.rb
@@ -20,11 +20,12 @@ require "pacto/instantiated_contract"
 require "pacto/contract"
 require "pacto/contract_factory"
 require "pacto/file_pre_processor"
+require "pacto/meta_schema"
 
 module Pacto
   def self.validate_contract contract
     begin
-      Pacto::ContractFactory.validate_contract contract
+      Pacto::MetaSchema.new.validate contract
       puts "All contracts successfully meta-validated"
       true
     rescue InvalidContract => e

--- a/lib/pacto/contract_factory.rb
+++ b/lib/pacto/contract_factory.rb
@@ -1,23 +1,16 @@
 module Pacto
   class ContractFactory
-    def self.contract_schema
-      File.join(File.dirname(File.expand_path(__FILE__)), '../../resources/contract_schema.json')
-    end
-
     def self.build_from_file(contract_path, host, file_pre_processor)
       contract_definition_expanded = file_pre_processor.process(File.read(contract_path))
       definition = JSON.parse(contract_definition_expanded)
-      validate_contract definition
+      schema.validate definition
       request = Request.new(host, definition["request"])
       response = Response.new(definition["response"])
       Contract.new(request, response)
     end
-    
-    def self.validate_contract definition
-      errors = JSON::Validator.fully_validate(contract_schema, definition)
-      unless errors.empty?
-        raise InvalidContract.new(errors)
-      end
+
+    def self.schema
+      @schema ||= MetaSchema.new
     end
   end
 end

--- a/lib/pacto/meta_schema.rb
+++ b/lib/pacto/meta_schema.rb
@@ -1,0 +1,17 @@
+module Pacto
+  class MetaSchema
+    attr_accessor :schema, :engine
+
+    def initialize(engine = JSON::Validator)
+      @schema = File.join(File.dirname(File.expand_path(__FILE__)), '../../resources/contract_schema.json')
+      @engine = engine
+    end
+
+    def validate definition
+      errors = engine.fully_validate(schema, definition)
+      unless errors.empty?
+        raise InvalidContract.new(errors)
+      end
+    end
+  end
+end

--- a/spec/unit/pacto/contract_factory_spec.rb
+++ b/spec/unit/pacto/contract_factory_spec.rb
@@ -18,35 +18,5 @@ module Pacto
         described_class.build_from_file(contract_path, host, file_pre_processor)
       end
     end
-
-    describe '.validate_contract' do
-      it 'should not raise error if contract is correct' do
-        expect {
-          definition = {
-            'request' => {
-              'method' => 'GET',
-              'path' => '/a/path',
-              'params' => {},
-              'headers' => {}
-            },
-            'response' => {
-              'status' => 200,
-              'headers' => {},
-              'body' => {
-                'type' => 'string',
-                'required' => true
-              }
-            }
-          }
-          described_class.validate_contract(definition)
-        }.not_to raise_error
-      end
-      
-      it 'should raise InvalidContract if contract do not contain a Request' do
-        expect {
-          described_class.validate_contract({})
-        }.to raise_error(InvalidContract)
-      end
-    end
   end
 end

--- a/spec/unit/pacto/meta_schema_spec.rb
+++ b/spec/unit/pacto/meta_schema_spec.rb
@@ -1,0 +1,70 @@
+module Pacto
+  describe MetaSchema do
+    let(:valid_contract) do
+      <<-EOF
+        {
+          "request": {
+            "method": "GET",    
+            "path": "/hello_world",
+            "headers": {
+              "Accept": "application/json"
+            },
+            "params": {}
+          },
+
+          "response": {
+            "status": 200,
+            "headers": {
+              "Content-Type": "application/json"
+            },
+            "body": {
+              "description": "A simple response",
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      EOF
+    end
+
+    let(:invalid_contract) do
+      <<-EOF
+        {
+          "request": {
+            "method": "GET",    
+            "path": "/hello_world",
+            "headers": {
+              "Accept": "application/json"
+            },
+            "params": {}
+          }
+
+        }
+      EOF
+    end
+
+    subject(:schema) { MetaSchema.new }
+
+    describe 'when validating a contract against the master schema' do
+      context 'with a valid contract structure' do
+        it 'should not raise any exceptions' do
+          expect {
+            schema.validate(valid_contract) 
+          }.to_not raise_error(Exception)
+        end
+      end
+
+      context 'with an invalid contract structure' do
+        it 'should raise InvalidContract exception' do
+          expect {
+            schema.validate(invalid_contract) 
+          }.to raise_error(InvalidContract)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
First part of an effort to move things out of the Pacto module into it's own classes, leaving only delegation on the module itself.
