### PR TITLE
allow access to contract response

### DIFF
--- a/lib/pacto/contract.rb
+++ b/lib/pacto/contract.rb
@@ -1,6 +1,7 @@
 module Pacto
   class Contract
     attr_reader :values
+    attr_reader :response
 
     def initialize(request, response, file = nil)
       @request = request


### PR DESCRIPTION
Item 4 from my earlier email:

"You should be able to get a stubbed response from a contract instance (Fog stubs)"

Perhaps there is a better solution in the long run, but this is definitely the easiest thing we can do to get it included in a release soon.
