### PR TITLE
Pacto generation - preserve exact request while generating (e.g. ERB)

### DIFF
--- a/lib/pacto/generator.rb
+++ b/lib/pacto/generator.rb
@@ -31,8 +31,9 @@ module Pacto
 
     def generate(request_file, host)
       contract = Pacto.build_from_file request_file, host
-      request = contract.request
-      response = request.execute
+      raw_contract = Pacto.build_from_file request_file, host, nil
+      request = raw_contract.request
+      response = contract.request.execute
       save(request_file, request, response)
     end
 

--- a/spec/unit/pacto/generator_spec.rb
+++ b/spec/unit/pacto/generator_spec.rb
@@ -12,7 +12,9 @@ module Pacto
           'Via' => ['Some Proxy'],
           'User-Agent' => ['rspec']
         },
-        'params' => []
+        'params' => {
+          'apikey' => "<%= ENV['MY_API_KEY'] %>"
+        }
       })
     end
     let(:response_adapter) do
@@ -48,6 +50,7 @@ module Pacto
       let(:generated_contract) { double('generated contract') }
       before do
         Pacto.should_receive(:build_from_file).with(request_file, record_host).and_return request_contract
+        Pacto.should_receive(:build_from_file).with(request_file, record_host, nil).and_return request_contract
         request.should_receive(:execute).and_return response_adapter
       end
 
@@ -97,6 +100,11 @@ module Pacto
           generated_request = subject['request']
           expect(generated_request['params']).to eq(request.params)
           expect(generated_request['path']).to eq(request.path)
+        end
+
+        it 'preserves ERB in the request params' do
+          generated_request = subject['request']
+          expect(generated_request['params']['apikey']).to eq("<%= ENV['MY_API_KEY'] %>")
         end
 
         it 'keeps important request headers' do


### PR DESCRIPTION
I think this is desired, so the request definition can have API keys or other sensitive data in it that the generator won't record.

The implementation is simple but hacky (loading the contract twice), but I'm trying to limit the changes to the generator for now.  We can reflect and prioritize potential pacto-core changes that would clean this up.
