### PR TITLE
Location header

### DIFF
--- a/lib/pacto.rb
+++ b/lib/pacto.rb
@@ -1,5 +1,6 @@
 require 'pacto/version'
 
+require 'addressable/template'
 require 'httparty'
 require 'hash_deep_merge'
 require 'multi_json'

--- a/pacto.gemspec
+++ b/pacto.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'webmock'
+  gem.add_dependency 'addressable'
   gem.add_dependency 'multi_json'
   gem.add_dependency 'json-schema', '~> 2.0'
   gem.add_dependency 'json-generator', '>= 0.0.5'


### PR DESCRIPTION
Basic fix for #66 - Dealing with Location Response Header.  It doesn't support the partial expansion, because we don't currently pass the request_signature to response validation.

I would like to add request validation and clean up response validation, but I'd still like to get this merged first because it lets me start writing contracts that take advantage of URI templates, then get an added bonus when a later release of Pacto adds stricter validation.

Changes:
- [x] Support URI templates in Location Header
- [ ] Partial expansion (deferred to future refactor)
- [ ] README update
