### PR TITLE
Remove register contract from config

### DIFF
--- a/lib/pacto/core/configuration.rb
+++ b/lib/pacto/core/configuration.rb
@@ -16,10 +16,6 @@ module Pacto
       @generator_options = { :schema_version => 'draft3' }
     end
 
-    def register_contract(contract = nil, *tags)
-      Pacto.register_contract(contract, *tags)
-    end
-
     def register_callback(callback = nil, &block)
       if block_given?
         @callback = Pacto::Callback.new(&block)

--- a/spec/unit/pacto/core/contract_repository_spec.rb
+++ b/spec/unit/pacto/core/contract_repository_spec.rb
@@ -51,12 +51,10 @@ describe Pacto do
 
     context 'with a block' do
       it 'has a compact syntax for registering multiple contracts' do
-        described_class.configure do |c|
-          c.register_contract 'new_api/create_item_v2', :item, :new
-          c.register_contract 'authentication', :default
-          c.register_contract 'list_items_legacy', :legacy
-          c.register_contract 'get_item_legacy', :legacy
-        end
+        described_class.register_contract 'new_api/create_item_v2', :item, :new
+        described_class.register_contract 'authentication', :default
+        described_class.register_contract 'list_items_legacy', :legacy
+        described_class.register_contract 'get_item_legacy', :legacy
         expect(described_class.registered[:new]).to include('new_api/create_item_v2')
         expect(described_class.registered[:default]).to include('authentication')
         expect(described_class.registered[:legacy]).to include('list_items_legacy', 'get_item_legacy')


### PR DESCRIPTION
The method `Pacto.configure.register_contract` it was only used on the unit tests.
There is not too much value to have it since only delegates the call to a Pacto module.
