### PR TITLE
Skip generating a body if there is no schema

### DIFF
--- a/lib/pacto/response.rb
+++ b/lib/pacto/response.rb
@@ -10,19 +10,17 @@ module Pacto
     end
 
     def instantiate
-      params = default_params
-      params.delete(:body) unless @schema && !@schema.empty?
-      Faraday::Response.new(params)
+      Faraday::Response.new(default_env)
     end
 
     private
 
-    def default_params
-      {
-        :status => @definition['status'],
-        :response_headers => @definition['headers'],
-        :body => JSON::Generator.generate(@schema)
-      }
+    def default_env
+      {}.tap do | env |
+        env[:status] = @definition['status']
+        env[:response_headers] = @definition['headers']
+        env[:body] = JSON::Generator.generate(@schema) if @schema && !@schema.empty?
+      end
     end
   end
 end


### PR DESCRIPTION
It was generating a body and then removing it, which was error prone.
