### PR TITLE
Use Pacto.build_contract on the validation Rake task. Fixes #88

### DIFF
--- a/features/validate/validation.feature
+++ b/features/validate/validation.feature
@@ -1,0 +1,36 @@
+Feature: Validation
+
+  Validation ensures that a external service conform to a Contract.
+
+  Scenario: Validation via a rake task
+    Given a file named "contracts/simple_contract.json" with:
+      """
+          {
+          "request": {
+            "method": "GET",
+            "path": "/hello",
+            "headers": { "Accept": "application/json" },
+            "params": {}
+          },
+
+          "response": {
+            "status": 200,
+            "headers": { "Content-Type": "application/json" },
+            "body": {
+              "description": "A simple response",
+              "type": "object",
+              "properties": {
+                "message": { "type": "string" }
+              }
+            }
+          }
+        }
+      """
+      When I successfully run `bundle exec rake pacto:validate['http://localhost:8000','tmp/aruba/contracts/simple_contract.json']`
+      Then the output should contain:
+        """"
+        Validating contracts in directory tmp/aruba/contracts/simple_contract.json against host http://localhost:8000
+
+        simple_contract.json: OK!
+        1 valid contract
+        """

--- a/lib/pacto/rake_task.rb
+++ b/lib/pacto/rake_task.rb
@@ -66,7 +66,7 @@ module Pacto
       each_contract(dir) do |contract_file|
         contracts << contract_file
         print "#{contract_file.split('/').last}:"
-        contract = Pacto.build_from_file(contract_file, host)
+        contract = Pacto.build_contract(contract_file, host)
         errors = contract.validate
 
         if errors.empty?


### PR DESCRIPTION
The rake task was not working properly because it was using a deprecated
code.

A user journey test was added to prevent this happening this again.
