### PR TITLE
Trying out docco

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 # pre-install so we can speed up the test with `bundle install --local`,
 # avoiding Aruba timeouts.
 gem 'excon'
+gem 'octokit'

--- a/contract.js
+++ b/contract.js
@@ -1,0 +1,125 @@
+// A Pacto Contract is a json document that describes an expected interaction between a consumer and provider,
+// by describing the expected format of the HTTP request/response they will exchange.  Currently, Pacto Contracts
+// are only supported for HTTP services using JSON.
+// 
+// Pacto contracts make use of [json-schema](http://json-schema.org/) to define and validate
+// the request and response bodies, and support []
+{
+  // The request is described first.  Pacto may use this in order to:
+  // - Send a sample request to a provider so the response can be validated.
+  // - Validate a request sent by a consumer.
+  // - Match a request from a consumer in order to return a stub response.
+  "request": {
+    // The headers section describes [HTTP request headers](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Requests)
+    // that are normally part of the request.  In stricter modes, the actual headers must match the values in the contract in order
+    // for a service to be validated or stubbed.
+    "headers": {
+      "Accept": "application/vnd.github.beta+json",
+      "Accept-Encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+    },
+    // The [HTTP method](http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) used to
+    // send a sample request to a provider, or match a consumer request for stubbing.
+    "method": "get",
+    // The path portion of the URL.  [RFC #6570](http://tools.ietf.org/html/rfc6570) URI templates are supported for
+    // stubbing, but not for creating sample requests.
+    "path": "/repos/thoughtworks/pacto/readme"
+  },
+  // The response section may be used to:
+  // - Create a stubbed response.
+  // - Validate a response sent by a provider (for sample or real consumer requests).
+  "response": {
+    // The headers section describes [HTTP response headers](http://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Responses)
+    // that are normally sent during the response.  In stricter modes, the actual headers must match the expected values in this
+    // contract, or the response will be considered invalid.
+    "headers": {
+      "Content-Type": "application/json; charset=utf-8",
+      // Note: this Status response header is in addition to the status code sent as part of an HTTP response.
+      // Most services do not send this.
+      "Status": "200 OK",
+      "Cache-Control": "public, max-age=60, s-maxage=60",
+      "Etag": "\"d52cb23e9b05c6af619094a00fb5da46\"",
+      // Multiple values can be specified with an array.
+      // The Vary header is used when generating contracts, in order to decide which request
+      // headers should be kept.  Request headers that are not in this list will be discarded.
+      "Vary": [
+        "Accept",
+        "Accept-Encoding"
+      ],
+      "Access-Control-Allow-Credentials": "true",
+      "Access-Control-Expose-Headers": "ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval",
+      "Access-Control-Allow-Origin": "*"
+    },
+    // The HTTP status code for stubbing and validation.
+    "status": 200,
+    // The body is a [json-schema](http://json-schema.org/) description of the HTTP response body.
+    "body": {
+      // Currently, only json-schema draft-03 is supported.
+      "$schema": "http://json-schema.org/draft-03/schema#",
+      // The generator creates these comments so it is easier to diff a change and see if the
+      // contract was regenerated or edited by hand.
+      "description": "Generated from vcr with shasum 3ae59164c6d9f84c0a81f21fb63e17b3b8ce6894",
+      "type": "object",
+      "required": true,
+      "properties": {
+        "name": {
+          "type": "string",
+          "required": true
+        },
+        "path": {
+          "type": "string",
+          "required": true
+        },
+        "sha": {
+          "type": "string",
+          "required": true
+        },
+        "size": {
+          "type": "integer",
+          "required": true
+        },
+        "url": {
+          "type": "string",
+          "required": true
+        },
+        "html_url": {
+          "type": "string",
+          "required": true
+        },
+        "git_url": {
+          "type": "string",
+          "required": true
+        },
+        "type": {
+          "type": "string",
+          "required": true
+        },
+        "content": {
+          "type": "string",
+          "required": true
+        },
+        "encoding": {
+          "type": "string",
+          "required": true
+        },
+        "_links": {
+          "type": "object",
+          "required": true,
+          "properties": {
+            "self": {
+              "type": "string",
+              "required": true
+            },
+            "git": {
+              "type": "string",
+              "required": true
+            },
+            "html": {
+              "type": "string",
+              "required": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples.rb
+++ b/samples.rb
@@ -1,0 +1,47 @@
+# Just require pacto to add it to your project.
+require 'pacto'
+# Pacto will disable live connections, so you will get an error if
+# your code unexpectedly calls an service that was not stubbed.  If you
+# want to re-enable connections, run `WebMock.allow_net_connect!`
+WebMock.allow_net_connect!
+
+# We can be configured via a block.
+# See the [Configuration documentation](https://www.relishapp.com/maxlinc/pacto/v/0-3-0/docs/configuration)
+# for more options.
+Pacto.configure do |c|
+  c.contracts_path = 'contracts'
+end
+
+# Calling `Pacto.generate!` enables [contract generation](https://www.relishapp.com/maxlinc/pacto/v/0-3-0/docs/generate).
+Pacto.generate!
+
+# Now, if we run any code that makes an HTTP call (using an
+# [HTTP library supported by WebMock](https://github.com/bblimke/webmock#supported-http-libraries))
+# then Pacto will generate a Contract based on the HTTP request/response.
+# 
+# This code snippet will generate a Contract and save it two `contracts/api.github.com/repos/thoughtworks/pacto/readme.json`.
+require 'octokit'
+readme = Octokit.readme 'thoughtworks/pacto'
+# We're getting back real data from GitHub, so this should be the actual file encoding.
+puts readme.encoding
+
+# The generated contract will contain expectations based on the request/response we observed,
+# including a best-guess at an appropriate json-schema.  Our heuristics certainly aren't foolproof,
+# so you might want to modify the output!
+
+# We can load the contract and validate it, by sending a new request and making sure
+# the response matches the JSON schema.  Obviously it will pass since we just recorded it,
+# but if the service has made a change, or if you alter the contract with new expectations,
+# then you will see a contract validation message.
+contracts = Pacto.build_contracts('contracts', 'https://api.github.com')
+contracts.validate_all
+
+# We can also use Pacto to stub the service based on the contract.
+contracts.stub_all
+# The stubbed data won't be very realistic, the default behavior is to return the simplest data
+# that complies with the schema.  That basically means that you'll have "bar" for every string.
+readme = Octokit.readme 'thoughtworks/pacto'
+# You're now getting stubbed data.  Unless you generated the schema with the `defaults` option enabled,
+# then this will just return "bar" as the encoding.  If you recorded the defaults, then it will return
+# the value received when the Contract was generated.
+puts readme.type


### PR DESCRIPTION
_WIP: but mergeable if you really feel like it_

Requires [docco](https://github.com/jashkenas/docco), installed via npm.  There is a ruby port (rocco), but it doesn't have as many features and the styling is currently broken.

You can generate documentation by runnning:

``` bash
$ npm install -g docco
$ docco samples.rb
$ docco contract.js
```

The contract.js is really supposed to be contract.json, but you can't use comments with json.  You can also try the different layouts: -l linear, -l parallel or -l classic.

Also, since it's just code ("literate programming") you can run `bundle exec ruby samples.rb` to make sure the samples are still valid.  It would also be possible to use contract.rb.md with docco, which would let github render it as markdown and run the code with [this gist](https://gist.github.com/hecticjeff/5034580).  The advantage of that approach would be that GitHub would render it as Markdown instead of code.
