### PR TITLE
Simplify ContractRegistry - remove tag support

### DIFF
--- a/lib/pacto/core/contract_registry.rb
+++ b/lib/pacto/core/contract_registry.rb
@@ -1,27 +1,12 @@
 module Pacto
-  class ContractRegistry
-    def initialize
-      @registry = Hash.new { |hash, key| hash[key] = Set.new }
-    end
-
-    def [](tag)
-      @registry[tag]
-    end
-
+  class ContractRegistry < Set
     def register(contract)
-      @registry[:default] << contract
-
-      self
+      fail ArgumentError, 'expected a Pacto::Contract' unless contract.is_a? Contract
+      add contract
     end
 
     def contracts_for(request_signature)
-      all_contracts.select { |c| c.matches? request_signature }
-    end
-
-    private
-
-    def all_contracts
-      @registry.values.inject(Set.new, :+)
+      select { |c| c.matches? request_signature }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,8 @@ RSpec.configure do |config|
     Pacto.clear!
   end
 end
+
+def sample_contract(name = 'simple_contract')
+  Pacto::ContractFactory.new.build_from_file "spec/integration/data/#{name}.json",
+                                             'http://localhost:8080'
+end

--- a/spec/unit/pacto/core/contract_registry_spec.rb
+++ b/spec/unit/pacto/core/contract_registry_spec.rb
@@ -4,38 +4,36 @@ module Pacto
   describe ContractRegistry do
     let(:tag) { 'contract_tag' }
     let(:another_tag) { 'another_tag' }
-    let(:contract) { double('contract') }
-    let(:contract_factory)  { double }
-    let(:another_contract) { double('another_contract') }
+    let(:contract) { sample_contract }
     let(:request_signature) { double('request signature') }
-    let(:contracts_that_match)      { create_contracts 2, true }
-    let(:contracts_that_dont_match) { create_contracts 3, false }
-    let(:all_contracts)             { contracts_that_match + contracts_that_dont_match }
 
     subject(:contract_registry) do
       ContractRegistry.new
     end
 
     describe '.register' do
-      context 'no tag' do
-        it 'registers the contract with the default tag' do
-          contract_registry.register contract
-          expect(contract_registry[:default]).to include(contract)
-        end
+      it 'registers the contract with the default tag' do
+        contract_registry.register contract
+        expect(contract_registry).to include(contract)
       end
     end
 
     describe '.contracts_for' do
+      before(:each) do
+        contract_registry.register contract
+      end
+
       context 'when no contracts are found for a request' do
         it 'returns an empty list' do
+          expect(contract).to receive(:matches?).with(request_signature).and_return false
           expect(contract_registry.contracts_for request_signature).to be_empty
         end
       end
 
       context 'when contracts are found for a request' do
         it 'returns the matching contracts' do
-          register_contracts all_contracts
-          expect(contract_registry.contracts_for request_signature).to eq(contracts_that_match)
+          expect(contract).to receive(:matches?).with(request_signature).and_return true
+          expect(contract_registry.contracts_for request_signature).to eq([contract])
         end
       end
     end

--- a/spec/unit/pacto/pacto_spec.rb
+++ b/spec/unit/pacto/pacto_spec.rb
@@ -44,19 +44,12 @@ describe Pacto do
   describe 'loading contracts' do
     let(:contracts_path) { 'path/to/dir' }
     let(:host) { 'localhost' }
-    let(:contract1)  { double }
-    let(:contract2)  { double }
-    let(:factory)  { double(:factory) }
-
-    before do
-      allow(Pacto::ContractFactory).to receive(:new).and_return(factory)
-    end
 
     it 'instantiates a contract list' do
-      allow(Pacto::ContractFiles).to receive(:for).with(contracts_path).and_return { %w{file1 file2} }
-      allow(factory).to receive(:build).with(%w{file1 file2}, host).and_return { [contract1, contract2] }
-      expect(Pacto::ContractList).to receive(:new).with([contract1, contract2])
-      Pacto.load_contracts(contracts_path, host)
+      expect(Pacto::ContractList).to receive(:new) do |contracts|
+        contracts.each { |contract| expect(contract).to be_a_kind_of(Pacto::Contract) }
+      end
+      Pacto.load_contracts('spec/integration/data/', host)
     end
   end
 end


### PR DESCRIPTION
There's no longer any documented way to use tags.  Since adding support for ContractLists in https://github.com/thoughtworks/pacto/pull/77, we've just been using lists instead.  This kills off all the dead code, basically turning ContractRegistry into a Set of Contracts with one helper method.

This makes searching a lot easier, which makes it easier to write rspec matchers.  I don't see a need for tags at this time, but they could be easily reintroduced by storing the tags on the contracts:

``` ruby
def find_by_tag(tag)
  Pacto.contract_registry.select{|c| c.tags.include? tag}
end
```
