### PR TITLE
Run samples via Polytrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ tmp
 .sublime*
 tags
 pacto.log
-docs/

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,5 @@ group :samples do
   gem 'pry'
   gem 'rack'
 end
+
+gem 'polytrix', git: 'https://github.com/rackerlabs/polytrix'

--- a/Rakefile
+++ b/Rakefile
@@ -36,18 +36,7 @@ end
 desc 'Run the samples'
 task :samples do
   FileUtils.rm_rf('samples/tmp')
-  Dir.chdir('samples') do
-    Bundler.with_clean_env do
-      system 'bundle install'
-      Dir['**/*.rb'].each do | sample_code_file |
-        next if sample_code_file =~ /sample_api/
-        sh "bundle exec ruby -rbundler/setup -rrspec/autorun #{sample_code_file}"
-      end
-      Dir['**/*.sh'].each do | sample_script |
-        sh "./#{sample_script}"
-      end
-    end
-  end
+  sh 'bundle exec polytrix exec --code2doc samples/*.rb samples/*.sh'
 end
 
 desc 'Build the documentation from the samples'

--- a/pacto.gemspec
+++ b/pacto.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json-schema-generator', '~> 0.0', '>= 0.0.7'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
 
+  gem.add_development_dependency 'polytrix', '~> 0.1.0.pre'
   gem.add_development_dependency 'coveralls', '~> 0'
   gem.add_development_dependency 'fabrication', '~> 2.11'
   gem.add_development_dependency 'rake', '~> 10.0'

--- a/polytrix.rb
+++ b/polytrix.rb
@@ -1,0 +1,5 @@
+require 'polytrix'
+
+Polytrix.configure do |polytrix|
+  polytrix.implementor name: 'pacto', basedir: "#{Dir.pwd}/samples"
+end

--- a/samples/samples.rb
+++ b/samples/samples.rb
@@ -6,9 +6,9 @@
 #
 # In addition to this document, here are some highlighted samples:
 # <ul>
-#   <li><a href="configuration.html">Configuration</a>: Shows all available configuration options</li>
-#   <li><a href="generation.html">Generation</a>: More details on generation</li>
-#   <li><a href="rspec.html">RSpec</a>: More samples for RSpec expectations</li>
+#   <li><a href="configuration">Configuration</a>: Shows all available configuration options</li>
+#   <li><a href="generation">Generation</a>: More details on generation</li>
+#   <li><a href="rspec">RSpec</a>: More samples for RSpec expectations</li>
 # </ul>
 
 # You can also find other samples using the Table of Content (upper right corner), including sample contracts.

--- a/samples/scripts/bootstrap
+++ b/samples/scripts/bootstrap
@@ -1,0 +1,2 @@
+#!/bin/bash
+bundle install

--- a/samples/scripts/wrapper
+++ b/samples/scripts/wrapper
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Polytrix should probably support different wrappers for different langauges
+extension="${1##*.}"
+if [ $extension = "rb" ];
+then
+  bundle exec ruby "$@"
+elif [ $extension = "sh" ];
+then
+  bash "$@"
+fi

--- a/samples/server_cli.sh
+++ b/samples/server_cli.sh
@@ -1,0 +1,12 @@
+# # Standalone server
+
+# You can run Pacto as a server in order to test non-Ruby projects. In order to get the full set
+# of options, run:
+bundle exec pacto-server -h
+
+# You probably want to run with the -sv option, which will display verbose output to stdout. You can
+# run server that proxies to a live endpoint:
+bundle exec pacto-server -sv --port 9000 --live http://example.com &
+bundle exec pacto-server -sv --port 9001 --stub &
+
+pkill -f pacto-server


### PR DESCRIPTION
I've been working on a gem called [Polytrix](https://github.com/rackerlabs/polytrix), which started out as a gem for doing polyglot compliance testing (checking code samples in multiple languages had the same behavior), but has some useful testing and documentation features even for pure ruby projects.

It will run all the samples/_.rb and samples/_.sh files and then convert them to markdown in docs. That can than be served via viewdocs.io, middleman, or whatever. So this can take the place of Aruba/Relish, and also avoid the need for something like Docco.
