### PR TITLE
Rake -> Thor

### DIFF
--- a/bin/pacto
+++ b/bin/pacto
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+require 'pacto/cli'
+
+Pacto::CLI::Main.start

--- a/features/evolve/existing_services.feature
+++ b/features/evolve/existing_services.feature
@@ -25,8 +25,8 @@ Feature: Existing services journey
     When I successfully run `bundle exec rake pacto:meta_validate['contracts']`
     Then the stdout should contain exactly:
     """
-    Validating contracts/www.example.com/service1.json
-    Validating contracts/www.example.com/service2.json
+       validated  contracts/www.example.com/service1.json
+       validated  contracts/www.example.com/service2.json
     All contracts successfully meta-validated
 
     """

--- a/features/validate/meta_validation.feature
+++ b/features/validate/meta_validation.feature
@@ -40,15 +40,6 @@ Feature: Meta-validation
     When I successfully run `bundle exec rake pacto:meta_validate['tmp/aruba/contracts/my_contract.json']`
     Then the stdout should contain "All contracts successfully meta-validated"
 
-  Scenario: Programmatic meta-validation
-    Given a file named "meta_validate.rb" with:
-    """ruby
-    require 'pacto'
-    Pacto.validate_contract 'contracts/my_contract.json'
-    """
-    When I successfully run `bundle exec ruby meta_validate.rb`
-    Then the stdout should contain "Validating contracts/my_contract.json"
-
 # The tests from here down should probably be specs instead of relish
 
   Scenario: Meta-validation of an invalid contract

--- a/features/validate/validation.feature
+++ b/features/validate/validation.feature
@@ -29,8 +29,7 @@ Feature: Validation
       When I successfully run `bundle exec rake pacto:validate['http://localhost:8000','tmp/aruba/contracts/simple_contract.json']`
       Then the stdout should contain:
         """"
-        Validating contracts in directory tmp/aruba/contracts/simple_contract.json against host http://localhost:8000
-
-        simple_contract.json: OK!
+        Validating contracts against host http://localhost:8000
+                 OK!  simple_contract.json
         1 valid contract
         """

--- a/lib/pacto.rb
+++ b/lib/pacto.rb
@@ -90,16 +90,10 @@ module Pacto
       contract_registry.contracts_for(request_signature)
     end
 
+    # @throws Pacto::InvalidContract
     def validate_contract(contract)
       Pacto::MetaSchema.new.validate contract
-      puts "Validating #{contract}"
       true
-    rescue InvalidContract => exception
-      puts 'Investigation errors detected'
-      exception.errors.each do |error|
-        puts "  Error: #{error}"
-      end
-      false
     end
 
     def load_contract(contract_path, host, format = :default)

--- a/lib/pacto/cli.rb
+++ b/lib/pacto/cli.rb
@@ -1,0 +1,75 @@
+require 'thor'
+require 'pacto'
+require 'pacto/cli/helpers'
+
+module Pacto
+  module CLI
+    class Main < Thor
+      include Pacto::CLI::Helpers
+
+      desc 'meta_validate [CONTRACTS...]', 'Validates a directory of contract definitions'
+      def meta_validate(*contracts)
+        invalid = []
+        each_contract(*contracts) do |contract_file|
+          begin
+            Pacto.validate_contract(contract_file)
+            say_status :validated, contract_file
+          rescue InvalidContract => exception
+            invalid << contract_file
+            shell.say_status :invalid, contract_file, :red
+            exception.errors.each do |error|
+              say set_color("  Error: #{error}", :red)
+            end
+          end
+        end
+        abort "The following contracts were invalid: #{invalid.join(',')}" unless invalid.empty?
+        say 'All contracts successfully meta-validated'
+      end
+
+      desc 'validate [CONTRACTS...]', 'Validates all contracts in a given directory against a given host'
+      method_option :host, type: :string, desc: 'Override host in contracts for validation'
+      def validate(*contracts)
+        host = options[:host]
+        WebMock.allow_net_connect!
+        banner = 'Validating contracts'
+        banner << " against host #{host}" unless host.nil?
+        say banner
+
+        invalid_contracts = []
+        tested_contracts = []
+        each_contract(*contracts) do |contract_file|
+          tested_contracts << contract_file
+          invalid_contracts << contract_file unless contract_is_valid?(contract_file, host)
+        end
+
+        validation_summary(tested_contracts, invalid_contracts)
+      end
+
+      private
+
+      def validation_summary(contracts, invalid_contracts)
+        if invalid_contracts.empty?
+          say set_color("#{contracts.size} valid contract#{contracts.size > 1 ? 's' : nil}", :green)
+        else
+          abort set_color("#{invalid_contracts.size} of #{contracts.size} failed. Check output for detailed error messages.", :red)
+        end
+      end
+
+      def contract_is_valid?(contract_file, host)
+        name = File.split(contract_file).last
+        contract = Pacto.load_contract(contract_file, host)
+        investigation = contract.simulate_request
+
+        if investigation.successful?
+          say_status 'OK!', name
+          true
+        else
+          say_status 'FAILED!', name, :red
+          say set_color(investigation.summary, :red)
+          say set_color(investigation.to_s, :red)
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/pacto/cli/helpers.rb
+++ b/lib/pacto/cli/helpers.rb
@@ -1,0 +1,20 @@
+module Pacto
+  module CLI
+    module Helpers
+      def each_contract(*contracts)
+        [*contracts].each do |contract|
+          if File.file? contract
+            yield contract
+          else # Should we assume it's a dir, or also support glob patterns?
+            contracts = Dir[File.join(contract, '**/*{.json.erb,.json}')]
+            fail Pacto::UI.colorize("No contracts found in directory #{contract}", :yellow) if contracts.empty?
+
+            contracts.sort.each do |contract_file|
+              yield contract_file
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/pacto/pacto_spec.rb
+++ b/spec/unit/pacto/pacto_spec.rb
@@ -18,26 +18,17 @@ describe Pacto do
 
   describe '.validate_contract' do
     context 'valid' do
-      it 'displays a success message and return true' do
+      it 'returns true' do
         mock_investigation []
         success = described_class.validate_contract 'my_contract.json'
-        expect(output).to eq 'Validating my_contract.json'
         expect(success).to be true
       end
     end
 
     context 'invalid' do
-      it 'displays one error messages and return false' do
+      it 'raises an InvalidContract error' do
         mock_investigation ['Error 1']
-        success = described_class.validate_contract 'my_contract.json'
-        expect(output).to match(/error/)
-        expect(success).to be_falsey
-      end
-
-      it 'displays several error messages and return false' do
-        mock_investigation ['Error 1', 'Error 2']
-        success = described_class.validate_contract 'my_contract.json'
-        expect(success).to be_falsey
+        expect { described_class.validate_contract 'my_contract.json' }.to raise_error(InvalidContract)
       end
     end
   end


### PR DESCRIPTION
I prefer Thor (w/ or w/out a CLI) for a few reasons:
- You can use it like Rake, but it's also better as CLIs. That's better for Pacto to become a polyglot project (Ruby bindings available, but CLI + server can be used for non-Ruby projects)
- Much better handling of arguments and options so you can do things like "--strict", vs Rake's hacky way of passing parameters.
- Better documentation for commands w/ descriptions of available options/arguments.
- Easier to test - they're just Ruby classes.
- A lot of useful helpers (see Thor::Shell and Thor::Actions especially)
