### PR TITLE
Restricted Webmock version to fix failing spec

### DIFF
--- a/features/evolve/existing_services.feature
+++ b/features/evolve/existing_services.feature
@@ -31,6 +31,8 @@ Feature: Existing services journey
 
     """
 
+  # TODO: find where Webmock is being called with and an empty :with
+  # and update it, to not use with so we can upgrade Webmock past 1.20.2
   @no-clobber
   Scenario: Stubbing with the contracts
     Given a file named "test.rb" with:

--- a/pacto.gemspec
+++ b/pacto.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'webmock', '~> 1.18'
+  gem.add_dependency 'webmock', '< 1.20.3'
   gem.add_dependency 'swagger-core', '~> 0.2', '>= 0.2.1'
   gem.add_dependency 'middleware', '~> 0.1'
   gem.add_dependency 'multi_json', '~> 1.8'


### PR DESCRIPTION
With [WebMock 1.20.3](https://github.com/bblimke/webmock/commit/5554c0d87b6ef341a10c89b344342f1b69621b6d) you can no longer use :with without any parameters, causing this feature to fail

```
cucumber features/evolve/existing_services.feature:35 # Scenario: Stubbing with the contracts
```

I restricted the gem version and added a todo, because I did not find exactly where the empty with was being called.
