### PR TITLE
Fix nil issue of example_uri_values(contract)

### DIFF
--- a/lib/pacto/actors/from_examples.rb
+++ b/lib/pacto/actors/from_examples.rb
@@ -57,7 +57,7 @@ module Pacto
         uri_template = contract.request.pattern.uri_template
         if contract.examples && contract.examples.values.first[:request][:uri]
           example_uri = contract.examples.values.first[:request][:uri]
-          uri_template.extract example_uri
+          uri_template.extract(example_uri) || {}
         else
           {}
         end


### PR DESCRIPTION
I got following error when simulate the contract with url like: http://abc.com?a=3&d=4

```
 Failure/Error: result = contracts.simulate_consumers
 TypeError:
   no implicit conversion of nil into Hash
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/actors/from_examples.rb:35:in `merge!'
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/actors/from_examples.rb:35:in `build_request'
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/consumer.rb:70:in `build_request'
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/consumer.rb:52:in `reenact'
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/contract.rb:64:in `execute'
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/contract.rb:40:in `simulate_request'
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/contract_set.rb:9:in `map'
 # /home/david/.rvm/gems/ruby-2.1.1/gems/pacto-0.4.0.rc1/lib/pacto/contract_set.rb:9:in `simulate_consumers'
```
