### PR TITLE
Fix swagger example stubbing

### DIFF
--- a/lib/pacto/core/pacto_response.rb
+++ b/lib/pacto/core/pacto_response.rb
@@ -18,7 +18,7 @@ module Pacto
       {
         status: status,
         headers: headers,
-        body: body
+        body: format_body(body)
       }
     end
 
@@ -26,6 +26,16 @@ module Pacto
       string = "STATUS: #{status}"
       string << " with body (#{raw_body.bytesize} bytes)" if raw_body
       string
+    end
+
+    private
+
+    def format_body(body)
+      if body.is_a?(Hash) || body.is_a?(Array)
+        body.to_json
+      else
+        body
+      end
     end
   end
 end

--- a/lib/pacto/formats/swagger/contract.rb
+++ b/lib/pacto/formats/swagger/contract.rb
@@ -71,7 +71,7 @@ module Pacto
             default: {
               request: {}, # Swagger doesn't have a clear way to capture request examples
               response: {
-                body: response_body
+                body: response_body.parse
               }
             }
           }

--- a/lib/pacto/formats/swagger/response_clause.rb
+++ b/lib/pacto/formats/swagger/response_clause.rb
@@ -25,6 +25,12 @@ module Pacto
           return nil unless swagger_response.schema
           swagger_response.schema.parse
         end
+
+        def to_hash
+          [:status, :headers, :schema].each_with_object({}) do | key, hash |
+            hash[key.to_s] = send key
+          end
+        end
       end
     end
   end

--- a/lib/pacto/stubs/webmock_adapter.rb
+++ b/lib/pacto/stubs/webmock_adapter.rb
@@ -62,12 +62,7 @@ module Pacto
 
         stub.to_return do |request|
           pacto_request = Pacto::Adapters::WebMock::PactoRequest.new request
-          response = contract.response_for pacto_request
-          {
-            status: response.status,
-            headers: response.headers,
-            body: format_body(response.body)
-          }
+          contract.response_for(pacto_request).to_hash
         end
       end
 
@@ -83,14 +78,6 @@ module Pacto
       end
 
       private
-
-      def format_body(body)
-        if body.is_a?(Hash) || body.is_a?(Array)
-          body.to_json
-        else
-          body
-        end
-      end
 
       def strict_details(request)
         {}.tap do |details|

--- a/spec/unit/pacto/formats/swagger/contract_spec.rb
+++ b/spec/unit/pacto/formats/swagger/contract_spec.rb
@@ -6,7 +6,7 @@ module Pacto
     module Swagger
       describe Contract do
         let(:swagger_yaml) do
-          ''"
+          %(
           swagger: '2.0'
           info:
             title: Sample API
@@ -23,7 +23,15 @@ module Pacto
                   200:
                     description: |-
                       Success.
-          "''
+                    examples:
+                      application/json: |-
+                        {
+                          "item": {
+                            "id": 45,
+                            "name": "basketball"
+                          }
+                        }
+          )
         end
         let(:swagger_definition) do
           ::Swagger.build(swagger_yaml, format: :yaml)
@@ -38,6 +46,12 @@ module Pacto
 
         subject(:contract) do
           described_class.new(api_operation, file: file)
+        end
+
+        describe 'contract examples' do
+          let(:example) { contract.examples }
+          it { expect(example).to be_truthy }
+          it { expect(example[:default][:response][:body]).to be_a(Hash) }
         end
 
         it_behaves_like 'a contract'


### PR DESCRIPTION
I was getting a few errors when trying to stub requests against a swagger contract that had examples.

First off, the Swagger::ResponseClause did not have a to_hash method defined, so it was throwing an error [here](https://github.com/thoughtworks/pacto/blob/master/lib/pacto/actors/from_examples.rb#L48).

Secondly, the Webmock was complaining because the stubbed response body was being set to a Swagger::V2::Example object, instead of a string. I fixed this by calling [parse](https://github.com/fishermand46/pacto/blob/2bd52fbe72a37973ebecba3a1d67e9d0f13cd050/lib/pacto/formats/swagger/contract.rb#L74) on the example object before setting it in the response hash.
