### PR TITLE
add INACTIVE notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 [![Dependency Status](https://gemnasium.com/thoughtworks/pacto.png)](https://gemnasium.com/thoughtworks/pacto)
 [![Coverage Status](https://coveralls.io/repos/thoughtworks/pacto/badge.png)](https://coveralls.io/r/thoughtworks/pacto)
 
+**Pacto is currently INACTIVE. Although this was a very nice and correct initiative,
+no "big parties" seems to be using it actively, therefore not maintaining this repository anymore. If you are interested in a more maintained Client-Driven Contracts gem, take a look at [Pact](https://github.com/realestate-com-au/pact).**
+
 **If you're viewing this at https://github.com/thoughtworks/pacto,
 you're reading the documentation for the master branch.
 [View documentation for the latest release
 (0.3.0).](https://github.com/thoughtworks/pacto/tree/v0.3.0)**
 
-# Pacto
+# [INACTIVE] Pacto
 
 Pacto is a judge that arbitrates contract disputes between a **service provider** and one or more **consumers**.  In other words, it is a framework for [Integration Contract Testing](http://martinfowler.com/bliki/IntegrationContractTest.html), and helps guide service evolution patterns like [Consumer-Driven Contracts](http://thoughtworks.github.io/pacto/patterns/cdc/) or [Documentation-Driven Contracts](http://thoughtworks.github.io/pacto/patterns/documentation_driven/).
 
@@ -101,7 +104,7 @@ This method will hit the real endpoint, with a request created based on the requ
 The response will be compared against the response part of the contract and any structural difference will
 generate a validation error.
 
-Running this in your build pipeline will ensure that your contracts actually match the real world, and that 
+Running this in your build pipeline will ensure that your contracts actually match the real world, and that
 you can run your acceptance tests against the contract stubs without worries.
 
 ### Stubbing
@@ -114,7 +117,7 @@ contracts.stub_providers
 ```
 
 This method uses webmock to ensure that whenever you make a request against one of contracts you actually get a stubbed response,
-based on the default values specified on the contract, instead of hitting the real provider. 
+based on the default values specified on the contract, instead of hitting the real provider.
 
 You can override any default value on the contracts by providing a hash of optional values to the stub_providers method. This
 will override the keys for every contract in the list


### PR DESCRIPTION
Since Pacto is not being used actively, we are not maintaining it and giving the attention required to keep an Open Source project alive and stable. 

So this note helps people to have the proper expectation while using it.
